### PR TITLE
Fix CI caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: Check style
         run: |
           gofmt -w -s .


### PR DESCRIPTION
actions/setup-go needs go.sum to cache properly, so you should run actions/checkout first